### PR TITLE
fix: Certificate validation fails for LocalMachine store and non-Engl…

### DIFF
--- a/MPARR2/MPARR-MicrosoftEntraUsers.ps1
+++ b/MPARR2/MPARR-MicrosoftEntraUsers.ps1
@@ -103,28 +103,27 @@ function CheckPowerShellVersion
 
 function CheckCertificateInstalled($thumbprint)
 {
-	$var = "False"
-	$certificates = @(Get-ChildItem Cert:\CurrentUser\My | Where-Object {$_.EnhancedKeyUsageList -like "*Client Authentication*"}| Select-Object Thumbprint) 
-	#$thumbprint -in $certificates
-	foreach($certificate in $certificates)
-	{
-		if($thumbprint -in $certificate.Thumbprint)
-		{
-			$var = "True"
-		}
-	 }
-	 if($var -eq "True")
-	 {
-		Write-Host "Certificate validation..." -NoNewLine
-		Write-Host "`t`t`t`tPassed!" -ForegroundColor Green
-		return $var
-	 }else
-	 {
-		Write-Host "`nCertificate installed on this machine is missing!!!" -ForeGroundColor Yellow
-		Write-Host "To execute this script unattended a certificate needs to be installed, the same used under Microsoft Entra App"
-		Start-Sleep -s 1
-		return $var
-	 }
+    $var = "False"
+    
+    $cert = Get-Item -Path "Cert:\LocalMachine\My\$thumbprint" -ErrorAction SilentlyContinue
+    if (-not $cert) {
+        $cert = Get-Item -Path "Cert:\CurrentUser\My\$thumbprint" -ErrorAction SilentlyContinue
+    }
+
+    if ($cert)
+    {
+        Write-Host "Certificate validation..." -NoNewLine
+        Write-Host "`t`t`t`tPassed!" -ForegroundColor Green
+        $var = "True"
+    }
+    else
+    {
+        Write-Host "`nCertificate installed on this machine is missing or inaccessible!!!" -ForeGroundColor Yellow
+        Write-Host "To execute this script unattended, a certificate matching the Microsoft Entra App must be installed in either the LocalMachine\My or CurrentUser\My store."
+        Start-Sleep -s 1
+    }
+    
+    return $var
 }
 
 function ValidateConfigurationFile


### PR DESCRIPTION
The `CheckCertificateInstalled` function in `MPARR-MicrosoftEntraUsers.ps1` (around line 107) doesn't work when certs are in the LocalMachine store or the OS isn't in English.

Currently, the script runs the following check:

`$certificates = @(Get-ChildItem Cert:\CurrentUser\My | Where-Object {$_.EnhancedKeyUsageList -like "*Client Authentication*"} | Select-Object Thumbprint)`

It only checks `Cert:\CurrentUser\My`, but scheduled tasks running under service accounts may have certs in `Cert:\LocalMachine\My`, so it fails even when a valid cert is on the server. The filter also matches on the literal string `*Client Authentication*`, which Windows translates on non-English installs, so valid certs get silently dropped.

The fix queries the provider paths directly, checks `LocalMachine\My` first with a fallback to `CurrentUser\My`, and matches on the thumbprint instead of the display string. Also simplifies the lookup by skipping the array/loop approach.